### PR TITLE
Fix newline handling in rainbow mode

### DIFF
--- a/gprint/gprint.py
+++ b/gprint/gprint.py
@@ -186,11 +186,14 @@ def gprint(message, rgb="default", new_line=True, rainbow_mode=False, return_me=
             if return_me:
                 temp_string = ""
                 for char in message:
-                    temp_string = temp_string + gprint(char, get_random(), new_line=False, return_me=True)
-                return(temp_string)
+                    temp_string += gprint(char, get_random(), new_line=False, return_me=True)
+                if new_line:
+                    temp_string += "\n"
+                return temp_string
             for char in message:
                 gprint(char, get_random(), new_line=False)
-            gprint("",new_line=True)
+            if new_line:
+                print()
         else:
             if rgb == "RANDOM":
                 rgb = get_random()

--- a/gprint/test_gprint.py
+++ b/gprint/test_gprint.py
@@ -16,6 +16,11 @@ def test_rainbow_mode(capsys):
     captured = capsys.readouterr()
     assert captured.out != "Hola mundo\n"
 
+def test_rainbow_no_newline(capsys):
+    gprint("Hola", rainbow_mode=True, new_line=False)
+    captured = capsys.readouterr()
+    assert not captured.out.endswith("\n")
+
 def test_no_newline(capsys):
     gprint("Hola mundo", new_line=False)
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
- fix newline handling for rainbow-mode printing
- add test coverage for no-newline rainbow-mode

## Testing
- `pytest -q`
